### PR TITLE
Fixed merkle proof error

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -20,7 +20,7 @@ const APP_NAME = "onboardjs";
 const whitelistAddresses = addresses;
 
 const leafNodes = whitelistAddresses.map((addr) => keccak256(addr));
-const merkleTree = new MerkleTree(leafNodes, keccak256, { sortPairs: true });
+const merkleTree = new MerkleTree(leafNodes, keccak256, { sortPairs: true ,duplicateOdd: true });
 
 //wallet options to provide to users
 const wallets = [


### PR DESCRIPTION
The merkle proof error was due to merkle tree generating without  `duplicateOdd: true` option in the script but in the merkle generation file